### PR TITLE
Fix transaction tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
         "bun-plugin-dts": "^0.2.1"
       },
       "devDependencies": {
-        "@types/bun": "latest"
+        "@types/bun": "latest",
+        "typescript": "^5.4.4"
       },
       "peerDependencies": {
         "typescript": "^5.0.0"

--- a/tests/transaction.spec.ts
+++ b/tests/transaction.spec.ts
@@ -8,10 +8,9 @@ describe('Transaction Model', () => {
       id: '456',
       timestamp: '2022-01-01T00:00:00Z',
       status: 'success',
+      success: true,
       message: 'Transaction completed successfully',
-      externalApiId: '789',
-      externalApi: 'API Name',
-      type: 'internal',
+      type: 'incoming',
     };
 
     expect(transaction).toBeDefined();
@@ -20,15 +19,14 @@ describe('Transaction Model', () => {
     expect(transaction.timestamp).toBe('2022-01-01T00:00:00Z');
     expect(transaction.status).toBe('success');
     expect(transaction.message).toBe('Transaction completed successfully');
-    expect(transaction.externalApiId).toBe('789');
-    expect(transaction.externalApi).toBe('API Name');
-    expect(transaction.type).toBe('internal');
+    expect(transaction.success).toBe(true);
+    expect(transaction.type).toBe('incoming');
   });
 
   it('should have valid transaction types', () => {
-    const validTypes: TransactionType[] = ['internal', 'external'];
+    const validTypes: TransactionType[] = ['incoming', 'outgoing'];
 
-    expect(validTypes).toContain('internal');
-    expect(validTypes).toContain('external');
+    expect(validTypes).toContain('incoming');
+    expect(validTypes).toContain('outgoing');
   });
 });


### PR DESCRIPTION
## Summary
- update transaction model tests to match the model
- lock file updated after installing dependencies

## Testing
- `npx tsc && bun test`

------
https://chatgpt.com/codex/tasks/task_e_687909cad8448320abc123474d9b1f08